### PR TITLE
Port the logic from refine_types_scala3 project

### DIFF
--- a/backend/src/common.scala
+++ b/backend/src/common.scala
@@ -1,0 +1,111 @@
+package backend
+
+import scala.util.control.NoStackTrace
+
+object common:
+
+  val controlLetter: Map[Int, String] = Map(
+    0 -> "T",
+    1 -> "R",
+    2 -> "W",
+    3 -> "A",
+    4 -> "G",
+    5 -> "M",
+    6 -> "Y",
+    7 -> "F",
+    8 -> "P",
+    9 -> "D",
+    10 -> "X",
+    11 -> "B",
+    12 -> "N",
+    13 -> "J",
+    14 -> "Z",
+    15 -> "S",
+    16 -> "Q",
+    17 -> "V",
+    18 -> "H",
+    19 -> "L",
+    20 -> "C",
+    21 -> "K",
+    22 -> "E"
+  )
+
+  // Do NOT change the order of the enumeration.
+  // The ordinal value of each letter corresponds with the remainder of number divided by 23
+  enum NieLetter:
+    case X // 0
+    case Y // 1
+    case Z // 2
+
+  object NieLetter:
+    def parse(letter: String): Either[InvalidNieLetter, NieLetter] =
+      Either.cond(
+        NieLetter.values.map(_.toString).contains(letter),
+        NieLetter.valueOf(letter),
+        InvalidNieLetter(letter)
+      )
+
+  // Do NOT change the order of the enumeration.
+  // The ordinal value of each letter corresponds with the remainder of number divided by 23
+  enum ControlLetter:
+    case T // 0
+    case R // 1
+    case W // 2
+    case A // 3
+    case G // 4
+    case M // 5
+    case Y // 6
+    case F // 7
+    case P // 8
+    case D // 9
+    case X // 10
+    case B // 11
+    case N // 12
+    case J // 13
+    case Z // 14
+    case S // 15
+    case Q // 16
+    case V // 17
+    case H // 18
+    case L // 19
+    case C // 20
+    case K // 21
+    case E // 22
+
+  object ControlLetter:
+    def parse(letter: String): Either[InvalidControlLetter, ControlLetter] =
+      Either.cond(
+        ControlLetter.values.map(_.toString).contains(letter),
+        ControlLetter.valueOf(letter),
+        InvalidControlLetter(letter)
+      )
+
+    def isValidId(number: Int, letter: ControlLetter): Boolean =
+      ControlLetter.fromOrdinal(number % 23) == letter
+
+  sealed trait FailedValidation(cause: String)
+      extends Exception
+      with NoStackTrace:
+    override def toString: String = cause
+  case class InvalidNieLetter(wrongInput: String)
+      extends FailedValidation(s"'$wrongInput' is not a valid NIE letter")
+  case class InvalidIdLetter(wrongInput: String)
+      extends FailedValidation(s"'$wrongInput' is not a valid ID letter")
+  case class InvalidControlLetter(wrongInput: String)
+      extends FailedValidation(
+        s"'$wrongInput' does not match the associated remainder letter"
+      )
+  case class InvalidNumber(wrongInput: String)
+      extends FailedValidation(s"'$wrongInput' should only contain digits")
+  case class InvalidNegativeNumber(wrongInput: Int)
+      extends FailedValidation(
+        s"'$wrongInput' is negative. It must be positive"
+      )
+  case class InvalidTooBigNumber(wrongInput: Int)
+      extends FailedValidation(
+        s"'$wrongInput' is too big. Max number is 99999999"
+      )
+  case class InvalidIdTooLong(wrongInput: String)
+      extends FailedValidation(
+        s"'$wrongInput' is too long. Max amount of characters is 9"
+      )

--- a/backend/src/server/CaskServer.scala
+++ b/backend/src/server/CaskServer.scala
@@ -1,3 +1,5 @@
+package backend
+
 //> using dependency com.lihaoyi::cask:0.10.2
 
 object CaskServer extends cask.MainRoutes {
@@ -13,30 +15,39 @@ object CaskServer extends cask.MainRoutes {
 
   @cask.post("/raw_class")
   def rawClass(request: cask.Request) = ???
+  // A_RawClasses.ID(request.text())
 
   @cask.post("/type_alias")
   def typeAlias(request: cask.Request) = ???
+  // B_TypeAliases.ID(request.text())
 
   @cask.post("/value_class")
   def valueClass(request: cask.Request) = ???
+  // C_ValueClasses.ID(request.text())
 
   @cask.post("/raw_class_validation")
   def rawClassValidation(request: cask.Request) = ???
+  // D_RawClassesWithValidation.ID(request.text())
 
   @cask.post("/opaque_type_validation")
   def opaqueTypeValidation(request: cask.Request) = ???
+  // E_OpaqueTypesWithValidation.ID(request.text())
 
   @cask.post("/vaule_class_error_handling")
   def valueClassErrorHandling(request: cask.Request) = ???
+  // F_ValueClassesWithErrorHandling.ID.parse(request.text())
 
   @cask.post("/opaque_type_error_handling")
   def opaqueTypeErrorHandling(request: cask.Request) = ???
+  // G_OpaqueTypesWithErrorHandling.ID.parse(request.text())
 
   @cask.post("/neo_type")
   def neoType(request: cask.Request) = ???
+  // NeoType.ID(request.text())
 
   @cask.post("/iron")
   def iron(request: cask.Request) = ???
+  // Iron.ID(request.text())
 
   @cask.post("/test_ok")
   def testOk(request: cask.Request) = ???

--- a/backend/src/vanilla/A_RawClasses.scala
+++ b/backend/src/vanilla/A_RawClasses.scala
@@ -1,0 +1,79 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Regular Classes in Scala=
+  *
+  * A regular class is defined using the 'class' keyword.
+  *
+  * Basic Syntax:
+  * {{{
+  *    class A (paramA: ParamAType, ..., paramN: ParamNType)
+  * }}}
+  *
+  * '''Key Features of Regular Classes'''
+  *   - Constructor parameters are defined directly in the class declaration
+  *   - Classes can have methods, fields, and other members
+  *   - Classes support method overriding using 'override' keyword
+  *
+  * ==Pros of Regular Classes==
+  *   - Straightforward object-oriented programming
+  *   - Full support for inheritance and polymorphism
+  *   - Encapsulation of data and behavior
+  *   - Flexibility in defining custom methods and fields
+  *   - Support for constructor parameters with default values
+  *
+  * ==Cons of Regular Classes==
+  *   - Each instance creates a new object in memory
+  *   - Can't be used as type aliases (unlike case classes)
+  *   - No built-in equals, hashCode, or toString methods (need manual
+  *     implementation)
+  *   - More verbose compared to case classes for data containers
+  *   - No automatic pattern matching support
+  */
+
+object A_RawClasses:
+
+  sealed trait ID
+
+  private final class DNI(number: Int, letter: String) extends ID:
+    require(number > 0, s"'$number' is negative. It must be positive")
+    require(number <= 99999999, s"'$number' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter),
+      s"'$letter' is not a valid ID letter"
+    )
+    override def toString: String = s"$number-$letter"
+
+  private final class NIE(nieLetter: String, number: Int, letter: String)
+      extends ID:
+    require(
+      NieLetter.values.map(_.toString).contains(nieLetter),
+      s"'$nieLetter' is not a valid NIE letter"
+    )
+    require(number > 0, s"'$number' is negative. It must be positive")
+    require(number <= 99999999, s"'$number' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter),
+      s"'$letter' is not a valid ID letter"
+    )
+    override def toString: String = s"$nieLetter-$number-$letter"
+
+  object ID:
+    def apply(input: String): ID =
+      val trimmed = input.trim
+      val withoutDash = trimmed.replace("-", "")
+      if withoutDash.head.isDigit
+      then
+        val (number, letter) = withoutDash.splitAt(8)
+        DNI(
+          number = number.toInt,
+          letter = letter
+        )
+      else
+        val (number, letter) = withoutDash.tail.splitAt(7)
+        NIE(
+          nieLetter = withoutDash.head.toString,
+          number = number.toInt,
+          letter = letter
+        )

--- a/backend/src/vanilla/B_TypeAliases.scala
+++ b/backend/src/vanilla/B_TypeAliases.scala
@@ -1,0 +1,78 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Type Aliases in Scala=
+  *
+  * Type aliases allow you to give alternative names to existing types. They are
+  * declared using the 'type' keyword.
+  *
+  * Basic Syntax:
+  * {{{
+  *    type NewTypeName = ExistingType
+  * }}}
+  *
+  * ==Pros of Type Aliases==
+  *   - Improved Readability: Makes code more domain-specific and
+  *     self-documenting by adding semantic meaning to primitive types
+  *   - Reduced Verbosity: Shortens complex type signatures; especially useful
+  *     for complex generic types
+  *   - Maintenance Benefits: Centralizes type definitions and makes refactoring
+  *     easier
+  *
+  * ==Cons of Type Aliases==
+  *   - No Type Safety: it does not provide type checking. Hence, it can't
+  *     prevent mixing of semantically different values of the same base type
+  *   - Potential Confusion: May mislead developers into thinking they provide
+  *     type safety; can make code more complex if overused
+  */
+
+object B_TypeAliases:
+
+  type NieLetter = String
+  type Number = Int
+  type Letter = String
+
+  sealed trait ID
+
+  private final class DNI(number: Number, letter: Letter) extends ID:
+    require(number > 0, s"'$number' is negative. It must be positive")
+    require(number <= 99999999, s"'$number' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter),
+      s"'$letter' is not a valid ID letter"
+    )
+    override def toString: String = s"$number-$letter"
+
+  private final class NIE(nieLetter: NieLetter, number: Number, letter: Letter)
+      extends ID:
+    require(
+      NieLetter.values.map(_.toString).contains(nieLetter),
+      s"'$nieLetter' is not a valid NIE letter"
+    )
+    require(number > 0, s"'$number' is negative. It must be positive")
+    require(number <= 99999999, s"'$number' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter),
+      s"'$letter' is not a valid ID letter"
+    )
+    override def toString: String = s"$nieLetter-$number-$letter"
+
+  object ID:
+    def apply(input: String): ID =
+      val trimmed = input.trim
+      val withoutDash = trimmed.replace("-", "")
+      if withoutDash.head.isDigit
+      then
+        val (number, letter) = withoutDash.splitAt(8)
+        DNI(
+          number = number.toInt,
+          letter = letter
+        )
+      else
+        val (number, letter) = withoutDash.tail.splitAt(7)
+        NIE(
+          nieLetter = withoutDash.head.toString,
+          number = number.toInt,
+          letter = letter
+        )

--- a/backend/src/vanilla/C_ValueClasses.scala
+++ b/backend/src/vanilla/C_ValueClasses.scala
@@ -1,0 +1,106 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Value Classes in Scala=
+  *
+  * A value class in Scala is a mechanism to define a wrapper around a single
+  * value without the runtime overhead of creating an actual instance of the
+  * wrapper class. For a regular class to become a value class, it must contain
+  * only one parameter and extend `AnyVal`.
+  *
+  * Basic Syntax:
+  * {{{
+  * class MyValueClass(val value: UnderlyingType) extends AnyVal
+  * }}}
+  *
+  * ==Key Features==
+  *   - Can only wrap one value
+  *   - Creates effectively a new type by masking the underlying type
+  *   - Zero-Cost Abstraction
+  *
+  * ==Pros of Value Classes==
+  *   - Type Safety: Provides compile-time type checking by preventing mixing up
+  *     different types that share the same underlying representation
+  *   - Zero-Cost Abstraction: Eliminates the wrapper class at runtime,
+  *     resulting in no performance overhead compared to using the underlying
+  *     type directly
+  *   - Domain Modeling: Helps create more meaningful domain types and makes the
+  *     code more readable and self-documenting
+  *   - Encapsulation: Allows the addition of methods to primitive types without
+  *     the need for inheritance and keeps related functionality together within
+  *     the wrapper class
+  *
+  * ==Cons of Value Classes==
+  *   - Limited Validation: Provides some enforcement of order but not much
+  *     more. Cannot prevent invalid values at compile time
+  *   - Restrictions: Can only have one parameter; cannot have auxiliary
+  *     constructors; cannot extend other classes (except for universal traits)
+  *   - Boxing Limitations: Performance benefits can be lost if boxing is
+  *     needed, such as for collections or generic methods
+  *   - Limited Inheritance: Cannot be extended by other classes and has limited
+  *     support for traits
+  */
+
+object C_ValueClasses:
+
+  private final class NIELetter(val value: String) extends AnyVal
+  private final class Number(val value: Int) extends AnyVal
+  private final class Letter(val value: String) extends AnyVal
+
+  sealed trait ID
+
+  private final class DNI(number: Number, letter: Letter) extends ID:
+    require(
+      number.value > 0,
+      s"'${number.value}' is negative. It must be positive"
+    )
+    require(
+      number.value <= 99999999,
+      s"'${number.value}' is too big. Max number is 99999999"
+    )
+    require(
+      ControlLetter.values.map(_.toString).contains(letter.value),
+      s"'${letter.value}' is not a valid ID letter"
+    )
+    override def toString: String = s"${number.value}-${letter.value}"
+
+  private final class NIE(nieLetter: NIELetter, number: Number, letter: Letter)
+      extends ID:
+    require(
+      NieLetter.values.map(_.toString).contains(nieLetter.value),
+      s"'${nieLetter.value}' is not a valid NIE letter"
+    )
+    require(
+      number.value > 0,
+      s"'${number.value}' is negative. It must be positive"
+    )
+    require(
+      number.value <= 99999999,
+      s"'${number.value}' is too big. Max number is 99999999"
+    )
+    require(
+      ControlLetter.values.map(_.toString).contains(letter.value),
+      s"'${letter.value}' is not a valid ID letter"
+    )
+    override def toString: String =
+      s"${nieLetter.value}-${number.value}-${letter.value}"
+
+  object ID:
+    def apply(input: String): ID =
+      val trimmed = input.trim
+      val withoutDash = trimmed.replace("-", "")
+      if withoutDash.head.isDigit
+      then
+        val (number, letter) = withoutDash.splitAt(8)
+        DNI(
+          number = Number(number.toInt),
+          letter = Letter(letter)
+        )
+      else
+        val (number, letter) = withoutDash.tail.splitAt(7)
+        NIE(
+          nieLetter = NIELetter(withoutDash.head.toString),
+          number = Number(number.toInt),
+          letter = Letter(letter)
+        )

--- a/backend/src/vanilla/D_RawClassesWithValidation.scala
+++ b/backend/src/vanilla/D_RawClassesWithValidation.scala
@@ -1,0 +1,94 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Regular Classes with Validation in Scala=
+  *
+  * Basic Syntax:
+  * {{{
+  *    class MyClass(val value: Int):
+  *      require(boolean_condition, "Error Message")
+  *      require(boolean_condition, "Error Message") // Multiple require statements can be defined
+  * }}}
+  *
+  * '''Key Language Features Used'''
+  *   - Constructor validation using 'require'
+  *   - Immutable class design
+  *
+  * ==Pros of Class-based Validation==
+  *   - Strong encapsulation of validation logic
+  *   - Immutability by design
+  *   - Clear separation of concerns
+  *   - Can have multiple parameters
+  *   - Full inheritance support
+  *   - More flexible than value classes
+  *
+  * ==Cons of Class-based Validation==
+  *   - Runtime overhead (object allocation)
+  *   - Memory footprint larger than value classes
+  *   - Potential performance impact with many instances
+  *   - GC pressure with large numbers of objects
+  */
+
+object D_RawClassesWithValidation:
+
+  private class NIELetter(val value: String) extends AnyVal
+  private class Number(val value: Int) extends AnyVal
+  private class Letter(val value: String) extends AnyVal
+
+  sealed trait ID
+
+  private final class DNI(number: Number, letter: Letter) extends ID:
+    require(
+      number.value > 0,
+      s"'${number.value}' is negative. It must be positive"
+    )
+    require(
+      number.value <= 99999999,
+      s"'${number.value}' is too big. Max number is 99999999"
+    )
+    require(
+      ControlLetter.values.map(_.toString).contains(letter.value),
+      s"'${letter.value}' is not a valid ID letter"
+    )
+    override def toString: String = s"${number.value}-${letter.value}"
+
+  private final class NIE(nieLetter: NIELetter, number: Number, letter: Letter)
+      extends ID:
+    require(
+      NieLetter.values.map(_.toString).contains(nieLetter.value),
+      s"'${nieLetter.value}' is not a valid NIE letter"
+    )
+    require(
+      number.value > 0,
+      s"'${number.value}' is negative. It must be positive"
+    )
+    require(
+      number.value <= 99999999,
+      s"'${number.value}' is too big. Max number is 99999999"
+    )
+    require(
+      ControlLetter.values.map(_.toString).contains(letter.value),
+      s"'${letter.value}' is not a valid ID letter"
+    )
+    override def toString: String =
+      s"${nieLetter.value}-${number.value}-${letter.value}"
+
+  object ID:
+    def apply(input: String): ID =
+      val trimmed = input.trim
+      val withoutDash = trimmed.replace("-", "")
+      if withoutDash.head.isDigit
+      then
+        val (number, letter) = withoutDash.splitAt(8)
+        DNI(
+          number = Number(number.toInt),
+          letter = Letter(letter)
+        )
+      else
+        val (number, letter) = withoutDash.tail.splitAt(7)
+        NIE(
+          nieLetter = NIELetter(withoutDash.head.toString),
+          number = Number(number.toInt),
+          letter = Letter(letter)
+        )

--- a/backend/src/vanilla/E_OpaqueTypesWithValidation.scala
+++ b/backend/src/vanilla/E_OpaqueTypesWithValidation.scala
@@ -1,0 +1,110 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Opaque types with Validation in Scala=
+  *
+  * Opaque types allow for type abstractions without runtime overhead. They
+  * provide type safety by defining new, distinct types from existing types and
+  * ensuring the correct use of these abstractions.
+  *
+  * Compared to type aliases, which are simply alternate names for existing
+  * types with no additional type safety, opaque types enforce stricter type
+  * constraints and encapsulate the underlying type's operations and
+  * representation.
+  *
+  * Basic Syntax:
+  * {{{
+  * opaque type OpaqueType = UnderlyingType
+  *
+  * object OpaqueType:
+  *   def apply(value: UnderlyingType): OpaqueType =
+  *     require(boolean_condition, "error message")
+  *     value
+  * }}}
+  *
+  * '''Key Features'''
+  *   - Creates new types, like classes, enums, etc.
+  *   - They only exists at compile time
+  *   - Can implement many of the features of classes and can also have a
+  *     companion object
+  *
+  * ==Pros of Opaque Types with Validation==
+  *   - Enhanced Type Safety: Encapsulates implementation details, ensuring that
+  *     only valid operations are performed on the type.
+  *   - Clearer Domain Modeling: Represents domain concepts more precisely by
+  *     creating new types instead of using primitive ones.
+  *   - Zero Overhead: Since opaque types are erased to their underlying types
+  *     at runtime, they do not introduce performance penalties.
+  *
+  * ==Cons of Opaque Types with Validation==
+  *   - Increased Complexity: May introduce additional complexity in the type
+  *     system, which can be challenging for new developers.
+  *   - Limited Interoperability: Sometimes difficult to work with libraries or
+  *     frameworks expecting the underlying type.
+  */
+
+object E_OpaqueTypesWithValidation:
+
+  opaque type NIELetter = String
+  private object NIELetter:
+    def apply(input: String): NIELetter =
+      require(NieLetter.values.map(_.toString).contains(input))
+      input
+
+  opaque type Number = Int
+  private object Number:
+    def apply(input: Int): Number =
+      require(input > 0)
+      require(input <= 99999999)
+      input
+
+  opaque type Letter = String
+  private object Letter:
+    def apply(input: String): Letter =
+      require(ControlLetter.values.map(_.toString).contains(input))
+      input
+
+  sealed trait ID
+
+  private final class DNI(number: Number, letter: Letter) extends ID:
+    require(number > 0, s"'$number' is negative. It must be positive")
+    require(number <= 99999999, s"'$number' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter),
+      s"'$letter' is not a valid ID letter"
+    )
+    override def toString: String = s"$number-$letter"
+
+  private final class NIE(nieLetter: NIELetter, number: Number, letter: Letter)
+      extends ID:
+    require(
+      NieLetter.values.map(_.toString).contains(nieLetter),
+      s"'$nieLetter' is not a valid NIE letter"
+    )
+    require(number > 0, s"'$number' is negative. It must be positive")
+    require(number <= 99999999, s"'$number' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter),
+      s"'$letter' is not a valid ID letter"
+    )
+    override def toString: String = s"$nieLetter-$number-$letter"
+
+  object ID:
+    def apply(input: String): ID =
+      val trimmed = input.trim
+      val withoutDash = trimmed.replace("-", "")
+      if withoutDash.head.isDigit
+      then
+        val (number, letter) = withoutDash.splitAt(8)
+        DNI(
+          number = Number(number.toInt),
+          letter = Letter(letter)
+        )
+      else
+        val (number, letter) = withoutDash.tail.splitAt(7)
+        NIE(
+          nieLetter = NIELetter(withoutDash.head.toString),
+          number = Number(number.toInt),
+          letter = Letter(letter)
+        )

--- a/backend/src/vanilla/F_ValueClassesWithErrorHandling.scala
+++ b/backend/src/vanilla/F_ValueClassesWithErrorHandling.scala
@@ -1,0 +1,144 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Value Classes with Error Handling in Scala=
+  *
+  * Value Classes provide a way to create type-safe wrappers around primitive
+  * types while maintaining runtime efficiency. When combined with companion
+  * objects and error handling, they offer a robust way to validate data at
+  * creation time. They are particularly useful in domains where data validation
+  * is crucial. This pattern helps catch errors early in the development cycle
+  * and provides clear feedback about validation failures, making systems more
+  * maintainable and reliable.
+  *
+  * Basic Syntax:
+  * {{{
+  * class ValueClass private (val value: Type) extends AnyVal
+  *
+  * object ValueClass:
+  *   def apply(value: Type): Either[Error, ValueClassType] =
+  *     Either.cond(
+  *       boolean_condition,
+  *       new ValueClass(value),
+  *       Error("Error message")
+  *     )
+  * }}}
+  *
+  * '''Key Features'''
+  *   - Type safety
+  *   - Validation control
+  *   - Use of Either for error handling
+  *
+  * ==Pros of Value Classes with Error Handling==
+  *   - Performance Benefits: No runtime overhead at instantiation; avoids
+  *     boxing/unboxing in most cases; memory efficient compared to regular
+  *     classes
+  *   - Safety Guarantees: Compile-time type safety; runtime validation
+  *     guarantees; immutable by design
+  *   - Developer Experience: Clear API boundaries; self-documenting code; easy
+  *     to maintain and refactor
+  *
+  * ==Cons of Value Classes with Error Handling==
+  *   - Implementation Complexity: Requires more initial setup code
+  *   - Usage Restrictions: Cannot extend other classes; Limited to a single
+  *     parameter; Some scenarios force boxing
+  *   - Learning Curve: Requires understanding of Either type; Pattern matching
+  *     knowledge needed; (Basic) Functional programming concepts required
+  */
+
+object F_ValueClassesWithErrorHandling:
+
+  private class NIELetter private (val value: String) extends AnyVal
+  private object NIELetter:
+    def either(nieLetter: String): Either[String, NIELetter] =
+      Either.cond(
+        NieLetter.values.map(_.toString).contains(nieLetter),
+        new NIELetter(nieLetter),
+        s"'$nieLetter' is not a valid NIE letter"
+      )
+
+  private class Number private (val value: Int) extends AnyVal
+  private object Number:
+    def either(number: Int): Either[String, Number] =
+      Either.cond(
+        number >= 0 && number <= 99999999,
+        new Number(number),
+        if number <= 0 then s"'$number' is negative. It must be positive"
+        else s"'$number' is too big. Max number is 99999999"
+      )
+
+  private class Letter private (val value: String) extends AnyVal
+  private object Letter:
+    def either(letter: String): Either[String, Letter] =
+      Either.cond(
+        ControlLetter.values.map(_.toString).contains(letter),
+        new Letter(letter),
+        s"'$letter' is not a valid ID letter"
+      )
+
+  sealed trait ID
+
+  private final class DNI private (number: Number, letter: Letter) extends ID:
+    require(number.value > 0, s"'${number.value}' is negative. It must be positive")
+    require(number.value <= 99999999, s"'${number.value}' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter.value),
+      s"'${letter.value}' is not a valid ID letter"
+    )
+    override def toString: String = s"${number.value}-${letter.value}"
+
+  private object DNI:
+    def either(
+        number: Either[String, Number],
+        letter: Either[String, Letter]
+    ): Either[String, DNI] =
+      for
+        n <- number
+        l <- letter
+      yield new DNI(n, l)
+
+  private final class NIE private (nieLetter: NIELetter, number: Number, letter: Letter) extends ID:
+    require(
+      NieLetter.values.map(_.toString).contains(nieLetter.value),
+      s"'${nieLetter.value}' is not a valid NIE letter"
+    )
+    require(number.value > 0, s"'${number.value}' is negative. It must be positive")
+    require(number.value <= 99999999, s"'${number.value}' is too big. Max number is 99999999")
+    require(
+      ControlLetter.values.map(_.toString).contains(letter.value),
+      s"'${letter.value}' is not a valid ID letter"
+    )
+    override def toString: String =
+      s"${nieLetter.value}-${number.value}-${letter.value}"
+
+  private object NIE:
+    def either(
+        nieLetter: Either[String, NIELetter],
+        number: Either[String, Number],
+        letter: Either[String, Letter]
+    ): Either[String, NIE] =
+      for
+        nl <- nieLetter
+        n <- number
+        l <- letter
+      yield new NIE(nl, n, l)
+
+  object ID:
+   def either(input: String): Either[String, ID] =
+     val trimmed = input.trim
+     val withoutDash = trimmed.replace("-", "")
+     if withoutDash.head.isDigit
+     then
+       val (number, letter) = withoutDash.splitAt(8)
+       DNI.either(
+         Number.either(number.toInt),
+         Letter.either(letter)
+       )
+     else
+       val (number, letter) = withoutDash.tail.splitAt(7)
+       NIE.either(
+         NIELetter.either(withoutDash.head.toString),
+         Number.either(number.toInt),
+         Letter.either(letter)
+       )

--- a/backend/src/vanilla/G_OpaqueTypesWithErrorHandling.scala
+++ b/backend/src/vanilla/G_OpaqueTypesWithErrorHandling.scala
@@ -1,0 +1,137 @@
+package backend.vanilla
+
+import backend.common.*
+
+/** =Opaque Types with Error Handling=
+  *
+  * Opaque types are a Scala 3 feature that provides type abstraction without
+  * runtime overhead. It allows to create new types that are light-weighted and
+  * can incorporate benefits of Value Classes and other structures.
+  *
+  * Basic syntax:
+  * {{{
+  * opaque type MyOpaqueType = UnderlyingType
+  * object MyOpaqueType:
+  *   def apply(underlyingValue: UnderlyingType): MyOpaqueType = underlyingValue
+  *   def parse(input: UnderlyingType): Either[String, MyOpaqueType] =
+  *     Either.cond(
+  *       // boolean_condition
+  *       MyOpaqueType(input),
+  *       "Error message"
+  *     )
+  * }}}
+  *
+  * '''Key Features'''
+  *   - Type safety
+  *   - Validation control
+  *   - Use of Either for error handling
+  *
+  * ==Pros of Opaque Types with Error Handling==
+  *   - Performance Benefits: No runtime overhead. Opaque types do not exist
+  *     during runtime.
+  *   - Safety Guarantees: Compile-time type safety; runtime validation
+  *     guarantees; immutable by design
+  *   - Developer Experience: Clear API boundaries; self-documenting code; easy
+  *     to maintain and refactor
+  *   - Encapsulation: Prevent invalid states through controlled construction
+  *
+  * ==Cons of Value Classes with Error Handling==
+  *   - Implementation Complexity: Opaque type's underlying representation is
+  *     only visible in the companion object; can make debugging more
+  *     challenging
+  *   - Usage Restrictions: Cannot extend other classes; Limited to a single
+  *     parameter; Some scenarios force boxing
+  *   - Learning Curve: Requires understanding of Either type; Pattern matching
+  *     knowledge needed; (Basic) Functional programming concepts required
+  *   - Potential Overuse: Can lead to unnecessary abstraction if not used
+  *     judiciously; might complicate simple code if used where not needed
+  */
+
+object G_OpaqueTypesWithErrorHandling:
+
+  opaque type NIELetter = String
+  private object NIELetter:
+    private def apply(input: String): NIELetter = input
+    def either(input: String): Either[String, NIELetter] =
+      Either.cond(
+        NieLetter.values.map(_.toString).contains(input),
+        NIELetter(input),
+        s"'$input' is not a valid NIE letter"
+      )
+
+  opaque type Number = Int
+  private object Number:
+    private def apply(number: Int): Number = number
+    def either(number: Int): Either[String, Number] =
+      Either.cond(
+        number > 0 && number <= 99999999,
+        Number(number),
+        if number <= 0 then s"'$number' is negative. It must be positive"
+        else s"'$number' is too big. Max number is 99999999"
+      )
+
+  opaque type Letter = String
+  private object Letter:
+    private def apply(input: String): Letter = input
+    def either(input: String): Either[String, Letter] =
+      Either.cond(
+     ControlLetter.values.map(_.toString).contains(input),
+        Letter(input),
+        s"'$input' is not a valid DNI letter"
+      )
+
+  sealed trait ID
+
+  private class DNI private (number: Number, letter: Letter) extends ID:
+    require(0 < number)
+    require(number <= 9999999)
+    require(ControlLetter.values.map(_.toString).contains(letter))
+    override def toString: String = s"$number-$letter"
+
+  private object DNI:
+    def either(
+        number: Either[String, Number],
+        letter: Either[String, Letter]
+    ): Either[String, DNI] =
+      for
+        n <- number
+        l <- letter
+      yield new DNI(n, l)
+
+  private class NIE private (nieLetter: NIELetter, number: Number, letter: Letter) extends ID:
+    require(NieLetter.values.map(_.toString).contains(nieLetter))
+    require(0 < number)
+    require(number <= 9999999)
+    require(ControlLetter.values.map(_.toString).contains(letter))
+    override def toString: String = s"$nieLetter-$number-$letter"
+
+  private object NIE:
+    def either(
+        nieLetter: Either[String, NIELetter],
+        number: Either[String, Number],
+        letter: Either[String, Letter]
+    ): Either[String, NIE] =
+      for
+        nl <- nieLetter
+        n <- number
+        l <- letter
+      yield new NIE(nl, n, l)
+
+  object ID:
+    def either(input: String): Either[String, ID] =
+      val trimmed = input.trim
+      val withoutDash = trimmed.replace("-", "")
+      if withoutDash.head.isDigit
+      then
+        val (number, letter) = withoutDash.splitAt(8)
+        DNI.either(
+          number = Number.either(number.toInt),
+          letter = Letter.either(letter)
+        )
+      else
+        val (number, letter) = withoutDash.tail.splitAt(7)
+        NIE.either(
+          nieLetter = NIELetter.either(withoutDash.head.toString),
+          number = Number.either(number.toInt),
+          letter = Letter.either(letter)
+        )


### PR DESCRIPTION
Add a comment on the server file to the methods to be linked. Add implementation for vanilla logic.

The ported code has been adapted to have an object `ID` with an `apply` or `either` method. It is the only public member, so the other structures are encapsulated to prevent naming conflicts.
